### PR TITLE
Added the `package_data' file to the `data' package

### DIFF
--- a/ISPy/data/package_data
+++ b/ISPy/data/package_data
@@ -1,0 +1,1 @@
+fts_disk_center_SI.idlsave


### PR DESCRIPTION
Packages providing data files (other than Python/Fortran/C/C++ source code) must list them in the `package_data` file located in their root folder; one entry per line, patterns allowed (see the `hello_py` package in the examples folder and check the [developer guidelines](https://github.com/ISP-SST/ISPy/wiki/Developer-guidelines))