### PR TITLE
Magnetic field conversion functions

### DIFF
--- a/ISPy/spec/bfield.py
+++ b/ISPy/spec/bfield.py
@@ -6,7 +6,7 @@ DTOR = u.deg.to('rad')
 def observer2spherical(bvec_in, degrees=False):
     """
     Convert the magnetic field vector in the observer's frame B(lon, hor, azi)
-    to spherical coordinate system B(field, inc, azi)
+    to spherical coordinate system B(tot, inc, azi)
 
     Parameters
     ----------
@@ -47,7 +47,7 @@ def observer2spherical(bvec_in, degrees=False):
 
 def spherical2observer(bvec_in, degrees=False):
     """
-    Convert the magnetic field vector in spherical coordinate system B(field,
+    Convert the magnetic field vector in spherical coordinate system B(tot,
     inc, azi) to the observer's frame B(lon, hor, azi)
     
     Parameters
@@ -81,7 +81,7 @@ def spherical2observer(bvec_in, degrees=False):
 
 def spherical2cartesian(bvec_in, azim0=0):
     """
-    Convert the magnetic field vector in spherical coordinate system B(field,
+    Convert the magnetic field vector in spherical coordinate system B(tot,
     inc, azi) to Cartesian coordinates B(x, y, z)
 
     Parameters
@@ -133,7 +133,7 @@ def spherical2cartesian(bvec_in, azim0=0):
 def cartesian2spherical(bvec_in, azim0=0, degrees=False):
     """
     Convert the magnetic field vector in Cartesian coordinates B(x, y, z) to
-    spherical coordinates B(field, inc, azi)
+    spherical coordinates B(tot, inc, azi)
 
     Parameters
     ----------

--- a/ISPy/spec/bfield.py
+++ b/ISPy/spec/bfield.py
@@ -88,7 +88,7 @@ def spherical2cartesian(bvec_in, azim0=0):
     ----------
     bvec_in : ndarray
         magnetic feld vector of shape (3,), (3, nx) or (3, ny, nx)
-    azim0 : {0, 1, 2, 3}
+    azim0 : {0, 1, 2, 3}, optional
         zero-azimith direction convention: +Y (azim0=0), +X (azim0=1), -Y
         (azim0=2), -X (azim0=3)
 
@@ -130,7 +130,7 @@ def spherical2cartesian(bvec_in, azim0=0):
     
     return bvec_out
 
-def cartesian2spherical(bvec_in, degrees=False):
+def cartesian2spherical(bvec_in, azim0=0, degrees=False):
     """
     Convert the magnetic field vector in Cartesian coordinates B(x, y, z) to
     spherical coordinates B(field, inc, azi)
@@ -139,6 +139,9 @@ def cartesian2spherical(bvec_in, degrees=False):
     ----------
     bvec_in : ndarray
         magnetic feld vector of shape (3,), (3, nx) or (3, ny, nx)
+    azim0 : {0, 1, 2, 3}, optional
+        zero-azimith direction convention: +Y (azim0=0), +X (azim0=1), -Y
+        (azim0=2), -X (azim0=3)
     degrees : bool, optional
         return the inclination and azimuth in degrees (default False = radians)
 
@@ -147,10 +150,6 @@ def cartesian2spherical(bvec_in, degrees=False):
     ndarray
         magnetic field vector of same shape as `bvec_in`, converted to spherical
         coordinates
-    
-    Notes
-    -----
-    +Y is assumed to be the zero-azimuth direction 
     
     Examples
     --------
@@ -161,7 +160,14 @@ def cartesian2spherical(bvec_in, degrees=False):
     bvec_out = np.copy(bvec_in)
     bvec_out[0] = np.sqrt(bvec_in[0]**2 + bvec_in[1]**2 + bvec_in[2]**2)
     bvec_out[1] = np.arccos(bvec_in[2] / bvec_out[0])
-    bvec_out[2] = np.arctan(-1.*bvec_in[0] / (bvec_in[1]+1e-20))  # +1e-20 to avoid ZeroDivisionError
+
+    # Take zero-azimuth direction into account
+    if (azim0 == 0) or (azim0 == 2):
+        bvec_out[2] = np.arctan(-1.*bvec_in[0] / (bvec_in[1]+1e-20))  # +1e-20 to avoid ZeroDivisionError
+    elif (azim0 == 1) or (azim0 == 3):
+        bvec_out[2] = np.arctan(bvec_in[1] / (bvec_in[0]+1e-20))  # +1e-20 to avoid ZeroDivisionError
+    else:
+        raise ValueError('spherical2cartesian: azim0 value invalid')
     
     # Correct for periodicity in solutions, i.e. map azimuth to [0,2pi)
     # Assumes +Y is zero-azimuth direction, increasing counter-clockwise

--- a/ISPy/spec/bfield.py
+++ b/ISPy/spec/bfield.py
@@ -1,0 +1,214 @@
+import numpy as np
+import astropy.units as u
+
+DTOR = u.deg.to('rad')
+
+def observer2spherical(bvec_in, degrees=False):
+    """
+    Convert the magnetic field vector in the observer's frame B(lon, hor, azi)
+    to spherical coordinate system B(field, inc, azi)
+
+    Parameters
+    ----------
+    bvec_in : ndarray
+        magnetic field vector of shape (3,), (3, nx) or (3, ny, nx)
+    degrees : bool, optional
+        return the inclination and azimuth in degrees (default False = radians)
+
+    Returns
+    -------
+    ndarray
+        magnetic field vector of same shape as `bvec_in`, converted to spherical
+        coordinates
+
+    Examples
+    --------
+    >>> import bfield
+    >>> bvec.shape
+    (3, 374, 175)
+    >>> bvec[2].min(), bvec[2].max()
+    (0.000711255066562444, 179.99998474121094)
+    >>> bsph = bfield.observer2spherical(bvec, degrees=True)
+    >>> bsph[2].min(), bsph[2].max()
+    (1.2413742733006074e-05, 3.1415923872736844)
+
+    """
+
+    bvec_out = np.copy(bvec_in)
+    bvec_out[0] = np.sqrt(bvec_in[0]**2 + bvec_in[1]**2)
+    bvec_out[1] = np.arccos(bvec_in[0]/bvec_out[0])
+    if bvec_in[2].max() > 2*np.pi: bvec_out[2] *= DTOR
+
+    if degrees is True:
+        bvec_out[1] /= DTOR
+        if bvec_in[2].max() <= 2*np.pi: bvec_out[2] /= DTOR
+
+    return bvec_out
+
+def spherical2observer(bvec_in, degrees=False):
+    """
+    Convert the magnetic field vector in spherical coordinate system B(field,
+    inc, azi) to the observer's frame B(lon, hor, azi)
+    
+    Parameters
+    ----------
+    bvec_in : ndarray
+        magnetic field vector of shape (3,), (3, nx) or (3, ny, nx)
+    degrees : bool, optional
+        return the azimuth in degrees (default False = radians)
+
+    Returns
+    -------
+    ndarray
+        magnetic field vector of same shape as `bvec_in`, converted to the
+        observer's frame
+
+    Examples
+    --------
+    >>> bobs = bfield.spherical2observer(bvec)
+    
+    """
+    
+    bvec_out = np.copy(bvec_in)
+    if bvec_in[1].max() > np.pi: bvec_in[1] *= DTOR
+    bvec_out[0] = bvec_in[0] * np.cos(bvec_in[1])
+    bvec_out[1] = np.sqrt(bvec_in[0]**2 - bvec_out[0]**2)
+    
+    if (degrees is True) and (bvec_in[2].max() <= 2*np.pi): 
+        bvec_out[2] /= DTOR
+
+    return bvec_out
+
+def spherical2cartesian(bvec_in):
+    """
+    Convert the magnetic field vector in spherical coordinate system B(field,
+    inc, azi) to Cartesian coordinates B(x, y, z)
+
+    Parameters
+    ----------
+    bvec_in : ndarray
+        magnetic feld vector of shape (3,), (3, nx) or (3, ny, nx)
+
+    Returns
+    -------
+    ndarray
+        magnetic field vector of same shape as `bvec_in`, converted to Cartesian
+        coordinates
+    
+    Notes
+    -----
+    +Y is assumed to be the zero-azimuth direction 
+
+    Examples
+    --------
+    >>> bxyz = bfield.spherical2cartesian(bvec)
+
+    """
+
+    bvec_out = np.copy(bvec_in)
+    if bvec_in[1].max() > np.pi: bvec_in[1] *= DTOR
+    if bvec_in[2].max() > 2*np.pi: bvec_in[2] *= DTOR 
+    bvec_out[0] = -bvec_in[0] * np.sin(bvec_in[1]) * np.sin(bvec_in[2])
+    bvec_out[1] = bvec_in[0] * np.sin(bvec_in[1]) * np.cos(bvec_in[2])
+    bvec_out[2] = bvec_in[0] * np.cos(bvec_in[1])
+    
+    return bvec_out
+
+def cartesian2spherical(bvec_in, degrees=False):
+    """
+    Convert the magnetic field vector in Cartesian coordinates B(x, y, z) to
+    spherical coordinates B(field, inc, azi)
+
+    Parameters
+    ----------
+    bvec_in : ndarray
+        magnetic feld vector of shape (3,), (3, nx) or (3, ny, nx)
+    degrees : bool, optional
+        return the inclination and azimuth in degrees (default False = radians)
+
+    Returns
+    -------
+    ndarray
+        magnetic field vector of same shape as `bvec_in`, converted to spherical
+        coordinates
+    
+    Notes
+    -----
+    +Y is assumed to be the zero-azimuth direction 
+    
+    Examples
+    --------
+    >>> bsph = bfield.cartesian2spherical(bvec, degrees=True)
+
+    """
+
+    bvec_out = np.copy(bvec_in)
+    bvec_out[0] = np.sqrt(bvec_in[0]**2 + bvec_in[1]**2 + bvec_in[2]**2)
+    bvec_out[1] = np.arccos(bvec_in[2] / bvec_out[0])
+    bvec_out[2] = np.arctan(-1.*bvec_in[0] / (bvec_in[1]+1e-20))  # +1e-20 to avoid ZeroDivisionError
+    
+    # Correct for periodicity in solutions, i.e. map azimuth to [0,2pi)
+    # Assumes +Y is zero-azimuth direction, increasing counter-clockwise
+    idx = np.where(bvec_in[1] < 0)
+    bvec_out[2][idx] += np.pi
+    idx = np.where((bvec_in[0] > 0) & (bvec_in[1] > 0))
+    bvec_out[2][idx] += 2*np.pi
+    
+    if degrees is True:
+        bvec_out[1] /= DTOR
+        bvec_out[2] /= DTOR
+
+    return bvec_out
+
+def observer2cartesian(bvec_in):
+    """
+    Convert the magnetic field vector in the observer's frame B(lon, hor, azi)
+    to Cartesian coordinates B(x, y, z).
+    Wrapper function around observer2spherical() and spherical2cartesian().
+    
+    Parameters
+    ----------
+    bvec_in : ndarray
+        magnetic feld vector of shape (3,), (3, nx) or (3, ny, nx)
+
+    Returns
+    -------
+    ndarray
+        magnetic field vector of same shape as `bvec_in`, converted to Cartesian
+        coordinates
+    
+    Examples
+    --------
+    >>> bxyz = bfield.observer2cartesian(bvec)
+
+    """
+    
+    return spherical2cartesian(observer2spherical(bvec_in))
+
+def cartesian2observer(bvec_in, degrees=False):
+    """
+    Convert the magnetic field vector in Cartesian coordinates B(x, y, z) to the
+    observer's frame B(lon, hor, azi)
+    Wrapper function around cartesian2spherical() and spherical2observer().
+    
+    Parameters
+    ----------
+    bvec_in : ndarray
+        magnetic feld vector of shape (3,), (3, nx) or (3, ny, nx)
+    degrees : bool, optional
+        return the azimuth in degrees (default False = radians)
+
+    Returns
+    -------
+    ndarray
+        magnetic field vector of same shape as `bvec_in`, converted to the
+        observer's frame
+    
+    Examples
+    --------
+    >>> bobs = bfield.cartesian2observer(bvec, degrees=True)
+
+    """
+
+    return spherical2observer(cartesian2spherical(bvec_in), degrees=degrees)
+

--- a/ISPy/spec/bfield.py
+++ b/ISPy/spec/bfield.py
@@ -3,10 +3,10 @@ import astropy.units as u
 
 DTOR = u.deg.to('rad')
 
-def los2spherical(bvec_in, degrees=False):
+def cylindrical2spherical(bvec_in, degrees=False):
     """
-    Convert the magnetic field vector B(lon, hor, azi) to spherical coordinate
-    system B(tot, inc, azi)
+    Convert the magnetic field vector in cylindrical decomposition B(lon, hor,
+    azi) to spherical decomposition B(tot, inc, azi)
 
     Parameters
     ----------
@@ -19,7 +19,7 @@ def los2spherical(bvec_in, degrees=False):
     -------
     ndarray
         magnetic field vector of same shape as `bvec_in`, converted to spherical
-        coordinates
+        decomposition
 
     Examples
     --------
@@ -28,7 +28,7 @@ def los2spherical(bvec_in, degrees=False):
     (3, 374, 175)
     >>> bvec[2].min(), bvec[2].max()
     (0.000711255066562444, 179.99998474121094)
-    >>> bsph = bfield.los2spherical(bvec, degrees=True)
+    >>> bsph = bfield.cylindrical2spherical(bvec, degrees=True)
     >>> bsph[2].min(), bsph[2].max()
     (1.2413742733006074e-05, 3.1415923872736844)
 
@@ -45,10 +45,10 @@ def los2spherical(bvec_in, degrees=False):
 
     return bvec_out
 
-def spherical2los(bvec_in, degrees=False):
+def spherical2cylindrical(bvec_in, degrees=False):
     """
-    Convert the magnetic field vector in spherical coordinate system B(tot,
-    inc, azi) to B(lon, hor, azi)
+    Convert the magnetic field vector in spherical decomposition B(tot, inc,
+    azi) to cylindrical decomposition B(lon, hor, azi)
     
     Parameters
     ----------
@@ -61,11 +61,11 @@ def spherical2los(bvec_in, degrees=False):
     -------
     ndarray
         magnetic field vector of same shape as `bvec_in`, converted to the
-        line-of-sight frame 
+        cylindrical decomposition
 
     Examples
     --------
-    >>> bobs = bfield.spherical2los(bvec)
+    >>> bobs = bfield.spherical2cylindrical(bvec)
     
     """
     
@@ -81,8 +81,8 @@ def spherical2los(bvec_in, degrees=False):
 
 def spherical2cartesian(bvec_in, azim0=0):
     """
-    Convert the magnetic field vector in spherical coordinate system B(tot,
-    inc, azi) to Cartesian coordinates B(x, y, z)
+    Convert the magnetic field vector in spherical decomposotion B(tot, inc,
+    azi) to Cartesian decomposition B(x, y, z)
 
     Parameters
     ----------
@@ -96,7 +96,7 @@ def spherical2cartesian(bvec_in, azim0=0):
     -------
     ndarray
         magnetic field vector of same shape as `bvec_in`, converted to Cartesian
-        coordinates
+        decomposition
     
     Examples
     --------
@@ -132,8 +132,8 @@ def spherical2cartesian(bvec_in, azim0=0):
 
 def cartesian2spherical(bvec_in, azim0=0, degrees=False):
     """
-    Convert the magnetic field vector in Cartesian coordinates B(x, y, z) to
-    spherical coordinates B(tot, inc, azi)
+    Convert the magnetic field vector in Cartesian decomposition B(x, y, z) to
+    spherical decomposition B(tot, inc, azi)
 
     Parameters
     ----------
@@ -149,7 +149,7 @@ def cartesian2spherical(bvec_in, azim0=0, degrees=False):
     -------
     ndarray
         magnetic field vector of same shape as `bvec_in`, converted to spherical
-        coordinates
+        decomposition
     
     Examples
     --------
@@ -182,11 +182,11 @@ def cartesian2spherical(bvec_in, azim0=0, degrees=False):
 
     return bvec_out
 
-def los2cartesian(bvec_in, azim0=0):
+def cylindrical2cartesian(bvec_in, azim0=0):
     """
-    Convert the magnetic field vector B(lon, hor, azi) to Cartesian coordinates
-    B(x, y, z).
-    Wrapper function around los2spherical() and spherical2cartesian().
+    Convert the magnetic field vector in cylindrical decomposition B(lon, hor,
+    azi) to Cartesian decomposition B(x, y, z).
+    Wrapper function around cylindrical2spherical() and spherical2cartesian().
     
     Parameters
     ----------
@@ -200,21 +200,21 @@ def los2cartesian(bvec_in, azim0=0):
     -------
     ndarray
         magnetic field vector of same shape as `bvec_in`, converted to Cartesian
-        coordinates
+        decomposition
     
     Examples
     --------
-    >>> bxyz = bfield.los2cartesian(bvec)
+    >>> bxyz = bfield.cylindrical2cartesian(bvec)
 
     """
     
-    return spherical2cartesian(los2spherical(bvec_in), azim0=azim0)
+    return spherical2cartesian(cylindrical2spherical(bvec_in), azim0=azim0)
 
-def cartesian2los(bvec_in, azim0=0, degrees=False):
+def cartesian2cylindrical(bvec_in, azim0=0, degrees=False):
     """
-    Convert the magnetic field vector in Cartesian coordinates B(x, y, z) to
-    B(lon, hor, azi)
-    Wrapper function around cartesian2spherical() and spherical2los().
+    Convert the magnetic field vector in Cartesian decomposition B(x, y, z) to
+    cylindrical decomposition B(lon, hor, azi)
+    Wrapper function around cartesian2spherical() and spherical2cylindrical().
     
     Parameters
     ----------
@@ -230,13 +230,13 @@ def cartesian2los(bvec_in, azim0=0, degrees=False):
     -------
     ndarray
         magnetic field vector of same shape as `bvec_in`, converted to the
-        line-of-sight frame
+        cylindrical decomposition
     
     Examples
     --------
-    >>> bobs = bfield.cartesian2los(bvec, degrees=True)
+    >>> bobs = bfield.cartesian2cylindrical(bvec, degrees=True)
 
     """
 
-    return spherical2los(cartesian2spherical(bvec_in, azim0=azim0), degrees=degrees)
+    return spherical2cylindrical(cartesian2spherical(bvec_in, azim0=azim0), degrees=degrees)
 

--- a/ISPy/spec/bfield.py
+++ b/ISPy/spec/bfield.py
@@ -3,10 +3,10 @@ import astropy.units as u
 
 DTOR = u.deg.to('rad')
 
-def observer2spherical(bvec_in, degrees=False):
+def los2spherical(bvec_in, degrees=False):
     """
-    Convert the magnetic field vector in the observer's frame B(lon, hor, azi)
-    to spherical coordinate system B(tot, inc, azi)
+    Convert the magnetic field vector B(lon, hor, azi) to spherical coordinate
+    system B(tot, inc, azi)
 
     Parameters
     ----------
@@ -28,7 +28,7 @@ def observer2spherical(bvec_in, degrees=False):
     (3, 374, 175)
     >>> bvec[2].min(), bvec[2].max()
     (0.000711255066562444, 179.99998474121094)
-    >>> bsph = bfield.observer2spherical(bvec, degrees=True)
+    >>> bsph = bfield.los2spherical(bvec, degrees=True)
     >>> bsph[2].min(), bsph[2].max()
     (1.2413742733006074e-05, 3.1415923872736844)
 
@@ -45,10 +45,10 @@ def observer2spherical(bvec_in, degrees=False):
 
     return bvec_out
 
-def spherical2observer(bvec_in, degrees=False):
+def spherical2los(bvec_in, degrees=False):
     """
     Convert the magnetic field vector in spherical coordinate system B(tot,
-    inc, azi) to the observer's frame B(lon, hor, azi)
+    inc, azi) to B(lon, hor, azi)
     
     Parameters
     ----------
@@ -61,11 +61,11 @@ def spherical2observer(bvec_in, degrees=False):
     -------
     ndarray
         magnetic field vector of same shape as `bvec_in`, converted to the
-        observer's frame
+        line-of-sight frame 
 
     Examples
     --------
-    >>> bobs = bfield.spherical2observer(bvec)
+    >>> bobs = bfield.spherical2los(bvec)
     
     """
     
@@ -182,11 +182,11 @@ def cartesian2spherical(bvec_in, azim0=0, degrees=False):
 
     return bvec_out
 
-def observer2cartesian(bvec_in, azim0=0):
+def los2cartesian(bvec_in, azim0=0):
     """
-    Convert the magnetic field vector in the observer's frame B(lon, hor, azi)
-    to Cartesian coordinates B(x, y, z).
-    Wrapper function around observer2spherical() and spherical2cartesian().
+    Convert the magnetic field vector B(lon, hor, azi) to Cartesian coordinates
+    B(x, y, z).
+    Wrapper function around los2spherical() and spherical2cartesian().
     
     Parameters
     ----------
@@ -204,17 +204,17 @@ def observer2cartesian(bvec_in, azim0=0):
     
     Examples
     --------
-    >>> bxyz = bfield.observer2cartesian(bvec)
+    >>> bxyz = bfield.los2cartesian(bvec)
 
     """
     
-    return spherical2cartesian(observer2spherical(bvec_in), azim0=azim0)
+    return spherical2cartesian(los2spherical(bvec_in), azim0=azim0)
 
-def cartesian2observer(bvec_in, azim0=0, degrees=False):
+def cartesian2los(bvec_in, azim0=0, degrees=False):
     """
-    Convert the magnetic field vector in Cartesian coordinates B(x, y, z) to the
-    observer's frame B(lon, hor, azi)
-    Wrapper function around cartesian2spherical() and spherical2observer().
+    Convert the magnetic field vector in Cartesian coordinates B(x, y, z) to
+    B(lon, hor, azi)
+    Wrapper function around cartesian2spherical() and spherical2los().
     
     Parameters
     ----------
@@ -230,13 +230,13 @@ def cartesian2observer(bvec_in, azim0=0, degrees=False):
     -------
     ndarray
         magnetic field vector of same shape as `bvec_in`, converted to the
-        observer's frame
+        line-of-sight frame
     
     Examples
     --------
-    >>> bobs = bfield.cartesian2observer(bvec, degrees=True)
+    >>> bobs = bfield.cartesian2los(bvec, degrees=True)
 
     """
 
-    return spherical2observer(cartesian2spherical(bvec_in, azim0=azim0), degrees=degrees)
+    return spherical2los(cartesian2spherical(bvec_in, azim0=azim0), degrees=degrees)
 

--- a/ISPy/spec/bfield.py
+++ b/ISPy/spec/bfield.py
@@ -182,7 +182,7 @@ def cartesian2spherical(bvec_in, azim0=0, degrees=False):
 
     return bvec_out
 
-def observer2cartesian(bvec_in):
+def observer2cartesian(bvec_in, azim0=0):
     """
     Convert the magnetic field vector in the observer's frame B(lon, hor, azi)
     to Cartesian coordinates B(x, y, z).
@@ -192,6 +192,9 @@ def observer2cartesian(bvec_in):
     ----------
     bvec_in : ndarray
         magnetic feld vector of shape (3,), (3, nx) or (3, ny, nx)
+    azim0 : {0, 1, 2, 3}, optional
+        zero-azimith direction convention: +Y (azim0=0), +X (azim0=1), -Y
+        (azim0=2), -X (azim0=3)
 
     Returns
     -------
@@ -205,9 +208,9 @@ def observer2cartesian(bvec_in):
 
     """
     
-    return spherical2cartesian(observer2spherical(bvec_in))
+    return spherical2cartesian(observer2spherical(bvec_in), azim0=azim0)
 
-def cartesian2observer(bvec_in, degrees=False):
+def cartesian2observer(bvec_in, azim0=0, degrees=False):
     """
     Convert the magnetic field vector in Cartesian coordinates B(x, y, z) to the
     observer's frame B(lon, hor, azi)
@@ -217,6 +220,9 @@ def cartesian2observer(bvec_in, degrees=False):
     ----------
     bvec_in : ndarray
         magnetic feld vector of shape (3,), (3, nx) or (3, ny, nx)
+    azim0 : {0, 1, 2, 3}, optional
+        zero-azimith direction convention: +Y (azim0=0), +X (azim0=1), -Y
+        (azim0=2), -X (azim0=3)
     degrees : bool, optional
         return the azimuth in degrees (default False = radians)
 
@@ -232,5 +238,5 @@ def cartesian2observer(bvec_in, degrees=False):
 
     """
 
-    return spherical2observer(cartesian2spherical(bvec_in), degrees=degrees)
+    return spherical2observer(cartesian2spherical(bvec_in, azim0=azim0), degrees=degrees)
 

--- a/ISPy/spec/bfield.py
+++ b/ISPy/spec/bfield.py
@@ -79,7 +79,7 @@ def spherical2observer(bvec_in, degrees=False):
 
     return bvec_out
 
-def spherical2cartesian(bvec_in):
+def spherical2cartesian(bvec_in, azim0=0):
     """
     Convert the magnetic field vector in spherical coordinate system B(field,
     inc, azi) to Cartesian coordinates B(x, y, z)
@@ -88,6 +88,9 @@ def spherical2cartesian(bvec_in):
     ----------
     bvec_in : ndarray
         magnetic feld vector of shape (3,), (3, nx) or (3, ny, nx)
+    azim0 : {0, 1, 2, 3}
+        zero-azimith direction convention: +Y (azim0=0), +X (azim0=1), -Y
+        (azim0=2), -X (azim0=3)
 
     Returns
     -------
@@ -95,10 +98,6 @@ def spherical2cartesian(bvec_in):
         magnetic field vector of same shape as `bvec_in`, converted to Cartesian
         coordinates
     
-    Notes
-    -----
-    +Y is assumed to be the zero-azimuth direction 
-
     Examples
     --------
     >>> bxyz = bfield.spherical2cartesian(bvec)
@@ -108,8 +107,25 @@ def spherical2cartesian(bvec_in):
     bvec_out = np.copy(bvec_in)
     if bvec_in[1].max() > np.pi: bvec_in[1] *= DTOR
     if bvec_in[2].max() > 2*np.pi: bvec_in[2] *= DTOR 
-    bvec_out[0] = -bvec_in[0] * np.sin(bvec_in[1]) * np.sin(bvec_in[2])
-    bvec_out[1] = bvec_in[0] * np.sin(bvec_in[1]) * np.cos(bvec_in[2])
+
+    #Zero-azimuth direction
+    if azim0 == 0:
+        azim_x = -np.sin(bvec_in[2])
+        azim_y = np.cos(bvec_in[2])
+    elif azim0 == 1:
+        azim_x = np.cos(bvec_in[2])
+        azim_y = np.sin(bvec_in[2])
+    elif azim0 == 2:
+        azim_x = np.sin(bvec_in[2])
+        azim_y = -np.cos(bvec_in[2])
+    elif azim0 == 3:
+        azim_x = -np.cos(bvec_in[2])
+        azim_y = -np.sin(bvec_in[2])
+    else:
+        raise ValueError('spherical2cartesian: azim0 value invalid')
+
+    bvec_out[0] = bvec_in[0] * np.sin(bvec_in[1]) * azim_x
+    bvec_out[1] = bvec_in[0] * np.sin(bvec_in[1]) * azim_y
     bvec_out[2] = bvec_in[0] * np.cos(bvec_in[1])
     
     return bvec_out

--- a/ISPy/spec/bfield.py
+++ b/ISPy/spec/bfield.py
@@ -167,7 +167,7 @@ def cartesian2spherical(bvec_in, azim0=0, degrees=False):
     elif (azim0 == 1) or (azim0 == 3):
         bvec_out[2] = np.arctan(bvec_in[1] / (bvec_in[0]+1e-20))  # +1e-20 to avoid ZeroDivisionError
     else:
-        raise ValueError('spherical2cartesian: azim0 value invalid')
+        raise ValueError('cartesian2spherical: azim0 value invalid')
     
     # Correct for periodicity in solutions, i.e. map azimuth to [0,2pi)
     # Assumes +Y is zero-azimuth direction, increasing counter-clockwise


### PR DESCRIPTION
Convenience functions for converting `B(los, hor, azi)` to `B(tot, inc, azi)` or `B(x, y, z)` and vice-versa. Resolves #15