### PR TITLE
Magnetic field vector projection to cylindrical equal-area coordinates

### DIFF
--- a/ISPy/util/interpolate2d.py
+++ b/ISPy/util/interpolate2d.py
@@ -1,0 +1,198 @@
+import numpy
+
+
+def interpolate2d(x, y, Z, points, mode='linear', bounds_error=False):
+    """2D interpolation routine: it outputs an array with same length 
+    as points with interpolated values.
+
+    Parameters
+    ----------
+    x : array
+        x-coordinates of the mesh on which to interpolate
+    y : array
+        y-coordinates of the mesh on which to interpolate
+    Z : array
+        2D array of values for each x, y pair
+    points : array
+        Nx2 array of coordinates where interpolated values are sought
+    mode : str, optional
+        Determines the interpolation order, by default 'linear'
+    bounds_error : bool, optional
+        Boolean flag. If True an exception will be raised when interpolated 
+        values are requested outside the domain of the input data, by default False
+
+    :Authors: 
+        Modified from the SAFE library:
+        https://github.com/inasafe/python-safe/safe/engine/interpolation2d.py
+    """
+
+    # Input checks
+    x, y, Z, xi, eta = check_inputs(x, y, Z, points, mode, bounds_error)
+
+    # Identify elements that are outside interpolation domain or NaN
+    outside = (xi < x[0]) + (eta < y[0]) + (xi > x[-1]) + (eta > y[-1])
+    outside += numpy.isnan(xi) + numpy.isnan(eta)
+
+    inside = ~outside
+    xi = xi[inside]
+    eta = eta[inside]
+
+    # Find upper neighbours for each interpolation point
+    idx = numpy.searchsorted(x, xi, side='left')
+    idy = numpy.searchsorted(y, eta, side='left')
+
+    # Internal check (index == 0 is OK)
+    msg = ('Interpolation point outside domain. This should never happen. '
+           'Please email Ole.Moller.Nielsen@gmail.com')
+    if len(idx) > 0:
+        if not max(idx) < len(x):
+            raise RuntimeError(msg)
+    if len(idy) > 0:
+        if not max(idy) < len(y):
+            raise RuntimeError(msg)
+
+    # Get the four neighbours for each interpolation point
+    x0 = x[idx - 1]
+    x1 = x[idx]
+    y0 = y[idy - 1]
+    y1 = y[idy]
+
+    z00 = Z[idx - 1, idy - 1]
+    z01 = Z[idx - 1, idy]
+    z10 = Z[idx, idy - 1]
+    z11 = Z[idx, idy]
+
+    # Coefficients for weighting between lower and upper bounds
+    oldset = numpy.seterr(invalid='ignore')  # Suppress warnings
+    alpha = (xi - x0) / (x1 - x0)
+    beta = (eta - y0) / (y1 - y0)
+    numpy.seterr(**oldset)  # Restore
+
+    if mode == 'linear':
+        # Bilinear interpolation formula
+        dx = z10 - z00
+        dy = z01 - z00
+        z = z00 + alpha * dx + beta * dy + alpha * beta * (z11 - dx - dy - z00)
+    else:
+        # Piecewise constant (as verified in input_check)
+
+        # Set up masks for the quadrants
+        left = alpha < 0.5
+        right = -left
+        lower = beta < 0.5
+        upper = -lower
+
+        lower_left = lower * left
+        lower_right = lower * right
+        upper_left = upper * left
+
+        # Initialise result array with all elements set to upper right
+        z = z11
+
+        # Then set the other quadrants
+        z[lower_left] = z00[lower_left]
+        z[lower_right] = z10[lower_right]
+        z[upper_left] = z01[upper_left]
+
+    # Self test
+    if len(z) > 0:
+        mz = numpy.nanmax(z)
+        mZ = numpy.nanmax(Z)
+        msg = ('Internal check failed. Max interpolated value %.15f '
+               'exceeds max grid value %.15f ' % (mz, mZ))
+        if not(numpy.isnan(mz) or numpy.isnan(mZ)):
+            if not mz <= mZ:
+                raise RuntimeError(msg)
+
+    # Populate result with interpolated values for points inside domain
+    # and NaN for values outside
+    r = numpy.zeros(len(points))
+    r[inside] = z
+    r[outside] = numpy.nan
+
+    return r
+
+def check_inputs(x, y, Z, points, mode, bounds_error):
+    """Check inputs for interpolate2d function
+    """
+
+    msg = 'Only mode "linear" and "constant" are implemented. I got %s' % mode
+    if mode not in ['linear', 'constant']:
+        raise RuntimeError(msg)
+
+    try:
+        x = numpy.array(x)
+    except Exception:
+        msg = ('Input vector x could not be converted to numpy array: '
+               '%s' % str(e))
+        raise Exception(msg)
+
+    try:
+        y = numpy.array(y)
+    except Exception:
+        msg = ('Input vector y could not be converted to numpy array: '
+               '%s' % str(e))
+        raise Exception(msg)
+
+    msg = ('Input vector x must be monotoneously increasing. I got '
+           'min(x) == %.15f, but x[0] == %.15f' % (min(x), x[0]))
+    if not min(x) == x[0]:
+        raise RuntimeError(msg)
+
+    msg = ('Input vector y must be monotoneously increasing. '
+           'I got min(y) == %.15f, but y[0] == %.15f' % (min(y), y[0]))
+    if not min(y) == y[0]:
+        raise RuntimeError(msg)
+
+    msg = ('Input vector x must be monotoneously increasing. I got '
+           'max(x) == %.15f, but x[-1] == %.15f' % (max(x), x[-1]))
+    if not max(x) == x[-1]:
+        raise RuntimeError(msg)
+
+    msg = ('Input vector y must be monotoneously increasing. I got '
+           'max(y) == %.15f, but y[-1] == %.15f' % (max(y), y[-1]))
+    if not max(y) == y[-1]:
+        raise RuntimeError(msg)
+
+    try:
+        Z = numpy.array(Z)
+        m, n = Z.shape
+    except Exception:
+        msg = 'Z must be a 2D numpy array: %s'
+        raise Exception(msg)
+
+    Nx = len(x)
+    Ny = len(y)
+    msg = ('Input array Z must have dimensions %i x %i corresponding to the '
+           'lengths of the input coordinates x and y. However, '
+           'Z has dimensions %i x %i.' % (Nx, Ny, m, n))
+    if not (Nx == m and Ny == n):
+        raise RuntimeError(msg)
+
+    # Get interpolation points
+    points = numpy.array(points)
+    xi = points[:, 0]
+    eta = points[:, 1]
+
+    if bounds_error:
+        msg = ('Interpolation point %f was less than the smallest value in '
+               'domain %f and bounds_error was requested.' % (xi[0], x[0]))
+        if xi[0] < x[0]:
+            raise Exception(msg)
+
+        msg = ('Interpolation point %f was greater than the largest value in '
+               'domain %f and bounds_error was requested.' % (xi[-1], x[-1]))
+        if xi[-1] > x[-1]:
+            raise Exception(msg)
+
+        msg = ('Interpolation point %f was less than the smallest value in '
+               'domain %f and bounds_error was requested.' % (eta[0], y[0]))
+        if eta[0] < y[0]:
+            raise Exception(msg)
+
+        msg = ('Interpolation point %f was greater than the largest value in '
+               'domain %f and bounds_error was requested.' % (eta[-1], y[-1]))
+        if eta[-1] > y[-1]:
+            raise Exception(msg)
+
+    return x, y, Z, xi, eta

--- a/ISPy/util/transformation.py
+++ b/ISPy/util/transformation.py
@@ -1,0 +1,237 @@
+import numpy as np
+from astropy.io import fits
+import astropy.units as u
+import interpolate2d
+
+
+# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+def sphere2img(lat, lon, latc, lonc, xcenter, ycenter, rsun, peff):
+    """Conversion between Heliographic coordinates to CCD coordinates.
+    Ported from sphere2img written in IDL : Adapted from Cartography.c by Rick Bogart, 
+    by Xudong Sun [Eq 5&6 in https://arxiv.org/pdf/1309.2392.pdf]
+
+    Parameters
+    ----------
+    lat, lon : array, array
+        input heliographic coordinates (latitude and longitude)
+    latc, lonc : float, float
+        Heliographic longitud and latitude of the refenrence (center) pixel
+    xcenter, ycenter : float, float
+        Center coordinates in the image
+    rsun : float
+        Solar radius in pixels
+    peff : [type]
+        p-angle (CW rotation on the image nneded for the solar north to be +eta)
+
+    Returns
+    -------
+    array
+        Latitude and longitude in the new CCD coordinate system.
+    """
+    sin_asd = 0.004660
+    cos_asd = 0.99998914
+    last_latc = 0.0
+    cos_latc = 1.0
+    sin_latc = 0.0
+
+    if (latc != last_latc):
+        sin_latc = np.sin(latc)
+        cos_latc = np.cos(latc)
+        last_latc = latc
+
+    sin_lat = np.sin(lat)
+    cos_lat = np.cos(lat)
+    cos_lat_lon = cos_lat * np.cos(lon - lonc)
+
+    cos_cang = sin_lat * sin_latc + cos_latc * cos_lat_lon
+    r = rsun * cos_asd / (1.0 - cos_cang * sin_asd)
+    xr = r * cos_lat * np.sin(lon - lonc)
+    yr = r * (sin_lat * cos_latc - sin_latc * cos_lat_lon)
+
+    cospa = np.cos(peff)
+    sinpa = np.sin(peff)
+    xi = xr * cospa - yr * sinpa
+    eta = xr * sinpa + yr * cospa
+
+    xi = xi + xcenter
+    eta = eta + ycenter
+
+    return xi, eta
+
+
+
+# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+def vector_transformation(peff,latitude_out,longitude_out, B0,field_x_cea,
+        field_y_cea, field_z_cea, bvec2cea=False):
+    """
+    Magnetic field transformation matrix (see Allen Gary & Hagyard 1990)
+    [Eq 7 in https://arxiv.org/pdf/1309.2392.pdf]
+    """
+
+    nlat_out = len(latitude_out)
+    nlon_out = len(longitude_out)
+
+    PP = peff
+    if bvec2cea is False:
+        BB = latitude_out[None, 0:nlat_out] * np.pi / 180.0
+        LL = longitude_out[0:nlon_out, None] * np.pi / 180.0
+    else:
+        BB = latitude_out
+        LL = longitude_out
+    L0 = 0.0 # We use central meridian
+    Ldif = LL - L0
+
+    a11 = -np.sin(B0)*np.sin(PP)*np.sin(Ldif)+np.cos(PP)*np.cos(Ldif)
+    a12 = np.sin(B0)*np.cos(PP)*np.sin(Ldif)+np.sin(PP)*np.cos(Ldif)
+    a13 = -np.cos(B0)*np.sin(Ldif)
+    a21 = -np.sin(BB)*(np.sin(B0)*np.sin(PP)*np.cos(Ldif)+np.cos(PP)*np.sin(Ldif))-np.cos(BB)*np.cos(B0)*np.sin(PP)
+    a22 = np.sin(BB)*(np.sin(B0)*np.cos(PP)*np.cos(Ldif)-np.sin(PP)*np.sin(Ldif))+np.cos(BB)*np.cos(B0)*np.cos(PP)
+    a23 = -np.cos(B0)*np.sin(BB)*np.cos(Ldif)+np.sin(B0)*np.cos(BB)
+    a31 = np.cos(BB)*(np.sin(B0)*np.sin(PP)*np.cos(Ldif)+np.cos(PP)*np.sin(Ldif))-np.sin(BB)*np.cos(B0)*np.sin(PP)
+    a32 = -np.cos(BB)*(np.sin(B0)*np.cos(PP)*np.cos(Ldif)-np.sin(PP)*np.sin(Ldif))+np.sin(BB)*np.cos(B0)*np.cos(PP)
+    a33 = np.cos(BB)*np.cos(B0)*np.cos(Ldif)+np.sin(BB)*np.sin(B0)
+
+    field_x_h = a11 * field_x_cea + a12 * field_y_cea + a13 * field_z_cea
+    field_y_h = a21 * field_x_cea + a22 * field_y_cea + a23 * field_z_cea
+    field_z_h = a31 * field_x_cea + a32 * field_y_cea + a33 * field_z_cea
+
+    # field_z_h positive towards earth
+    # field_y_h positive towards south (-field_y_h = Bt_cea)
+    # field_x_h positive towards west
+
+    field_y_h *= -1.0
+
+    return field_x_h, field_y_h, field_z_h
+
+
+
+
+
+# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+def remapping2cea(fitsfile, field_x, field_y, field_z):
+    """Map projection of the original input into the cylindical equal area system (CEA).
+    It can also remap other physical quantities.
+
+    Parameters
+    ----------
+    fitsfile : Header Data Unit
+        Fitsfile used to extract information from the header
+    field_x, field_y, field_z: array
+        2D array with the magnetic field in cartesian coordinates
+
+    Returns
+    -------
+    array
+        Remaping of the magnetic field to the cylindical equal area system (CEA).
+
+    :Authors: 
+        Carlos Diaz (ISP/SU 2020), Gregal Vissers (ISP/SU 2020)
+
+    """
+    # Latitude at disk center [rad]
+    latc = fitsfile.header['CRLT_OBS']*np.pi/180.
+    B0 = np.copy(latc)
+    # Longitude at disk center [rad]. The output is in Carrington coordinates. We use central meridian
+    lonc = 0.0
+    L0 = 0.0
+    rsun = fitsfile.header['RSUN_OBS']
+
+    # Position angle of rotation axis
+    peff = -1.0*fitsfile.header['crota2'] * np.pi / 180.0
+    dx_arcsec = fitsfile.header['CDELT1']
+    rsun_px = rsun / dx_arcsec
+
+    # Plate locations of the image center, in units of the image radius, 
+    # and measured from the corner. The SHARP CEA pixels have a linear dimension 
+    # in the x-direction of 0.03 heliographic degrees in the rotated coordinate system
+    dl = 0.03
+    xcenter = fitsfile.header['crpix1']-1 # FITS start indexing at 1, not 0
+    ycenter = fitsfile.header['crpix2']-1 # FITS start indexing at 1, not 0
+    nlat_out = np.round((fitsfile.header['LATDTMAX'] - fitsfile.header['LATDTMIN'])/dl)
+    nlon_out = np.round((fitsfile.header['LONDTMAX'] - fitsfile.header['LONDTMIN'])/dl) # lon_max => LONDTMAX
+    nrebin = 1
+    nlat_out = int(np.round(nlat_out/nrebin)*nrebin)
+    nlon_out = int(np.round(nlon_out/nrebin)*nrebin)
+    nx_out = nlon_out
+    ny_out = nlat_out
+
+    latitude_out = np.arange(nlat_out)*dl + fitsfile.header['LATDTMIN']
+    longitude_out = np.arange(nlon_out)*dl + fitsfile.header['LONDTMIN']
+    lon_out = longitude_out[:, None] * np.pi / 180.0
+    lat_out = lonc + latitude_out[None, :] * np.pi / 180.0
+
+    lon_center = (fitsfile.header['LONDTMAX'] + fitsfile.header['LONDTMIN']) / 2. * np.pi/180.0
+    lat_center = (fitsfile.header['LATDTMAX'] + fitsfile.header['LATDTMIN']) / 2. * np.pi/180.0
+    # print(lat_cesnter,latitude_out,f[1].header['LATDTMIN'],f[1].header['LATDTMAX'])
+
+    # The SHARP CEA pixels have a linear dimension 
+    # in the x-direction of 0.03 heliographic degrees in the rotated coordinate system
+    dl = 0.03
+    x_out = (np.arange(nx_out)-(nx_out-1)/2.)*dl 
+    y_out = (np.arange(ny_out)-(ny_out-1)/2.)*dl 
+
+    x_it = x_out[:,None] * np.pi/180.0
+    y_it = y_out[None,:] * np.pi/180.0
+
+    # sswidl plane2sphere equations for lat and lon; in sswidl these are fed
+    # into sphere2img
+    lat_it = np.arcsin(np.cos(lat_center)*y_it + np.sin(lat_center)*np.sqrt(1.0-y_it**2)*np.cos(x_it))
+    lon_it = np.arcsin((np.sqrt(1.0-y_it**2)*np.sin(x_it))/np.cos(lat_it)) + lon_center
+
+    # Heliographic coordinate to CCD coordinate
+    xi, eta = sphere2img(lat_it, lon_it, latc, lonc, xcenter, ycenter, rsun_px, peff)
+    
+    x = np.arange(fitsfile.header['naxis1'])
+    y = np.arange(fitsfile.header['naxis2'])
+
+    # Interpolation (or sampling)
+    xi_eta = np.concatenate([xi.flatten()[:, None], eta.flatten()[:, None]], axis=1)
+    
+    field_x_int = interpolate2d.interpolate2d(x, y, field_x, xi_eta).reshape((nlon_out,nlat_out))
+    field_y_int = interpolate2d.interpolate2d(x, y, field_y, xi_eta).reshape((nlon_out,nlat_out))
+    field_z_int = interpolate2d.interpolate2d(x, y, field_z, xi_eta).reshape((nlon_out,nlat_out))
+    
+
+    return peff, lat_it, lon_it,latc, field_x_int, field_y_int, field_z_int
+    
+
+
+# ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+def bvec2cea(fitsfile, field_x, field_y, field_z):
+    """Transformation to Cylindrical equal area projection (CEA) from CCD
+    detector as it is donde with SHARPs according to Xudong Sun (2018).
+    Currently only works for SDO data.
+
+    Parameters
+    ----------
+    fitsfile : Header Data Unit
+        Fitsfile used to extract information from the header
+    field_x, field_y, field_z: array
+        2D array with the magnetic field in cartesian coordinates
+
+    Returns
+    -------
+    arrays
+        Three components of the magnetic field in heliocentric spherical coordinates and
+        in cylindrical equal are projection.
+    
+    Example
+    -------
+    >>> field_z = field * np.cos(inclination * np.pi / 180.0)
+    >>> field_hor = field * np.sin(inclination * np.pi / 180.0)
+    >>> field_y = field_hor * np.cos(azimuth * np.pi / 180.0)
+    >>> field_x = -field_hor * np.sin(azimuth * np.pi / 180.0)
+
+    >>> field_x_h2, field_y_h2, field_z_h2 = tsf.bvec2cea(f[1], field_x, field_y, field_z) 
+
+    :Authors: 
+        Carlos Diaz (ISP/SU 2020), Gregal Vissers (ISP/SU 2020)
+
+    """
+
+    # Map projetion
+    peff, lat_it, lon_it,latc, field_x_int, field_y_int, field_z_int = remapping2cea(fitsfile, field_x, field_y, field_z)
+    # Vector transformation
+    field_x_h, field_y_h, field_z_h = vector_transformation(peff,lat_it,lon_it,latc, field_x_int, field_y_int, field_z_int, bvec2cea=True)
+
+    return field_x_h, field_y_h, field_z_h


### PR DESCRIPTION
Issue #16. Transformation to Cylindrical equal area projection (CEA) from CCD detector coordinates as it is done with SHARPs according to Xudong Sun (2018). Currently only works for SDO data.