### PR TITLE
Fix of example extensions and small behaviour changes for the compilation of extensions

### DIFF
--- a/ISPy/examples/hello_cpp/__extensions__.ispy
+++ b/ISPy/examples/hello_cpp/__extensions__.ispy
@@ -1,10 +1,11 @@
 #!/bin/env python
 # -*- coding:utf-8 -*-
 
-from distutils.core import Extension
+from numpy.distutils.core import Extension
 
 # Documentation:
 # https://docs.python.org/3/distutils/apiref.html#distutils.core.Extension
+# https://numpy.org/doc/stable/reference/generated/numpy.distutils.core.Extension.html
 
 _hello_mod = Extension(
     '_helloworld',             # Name of the extension
@@ -21,8 +22,6 @@ _hello_mod = Extension(
     export_symbols       = [], # symbols to be exported from a shared extension
     depends              = [], # files that the extension depends on
     language             = '', # 'c', 'c++' or 'objc', normally auto-detected
-    optional             = False
-    # Optional extensions allow the build to continue even when they fail
     )
 
 ext_modules = [_hello_mod]

--- a/ISPy/examples/hello_cpp/__init__.py
+++ b/ISPy/examples/hello_cpp/__init__.py
@@ -12,4 +12,7 @@ This module implements the function `hello', a simple hello-world, and the
 class Hello, with its printMessage function.
 """
 
-from _helloworld import *
+try:
+    from _helloworld import *
+except:
+    raise ImportError("Could not load the `{0}' extension, check that it was properly compiled (or reinstall with the `--with-extensions' parameter)".format(__name__))

--- a/ISPy/examples/hello_f90/__extensions__.ispy
+++ b/ISPy/examples/hello_f90/__extensions__.ispy
@@ -5,6 +5,7 @@ from numpy.distutils.core import Extension
 
 # Documentation:
 # https://docs.python.org/3/distutils/apiref.html#distutils.core.Extension
+# https://numpy.org/doc/stable/reference/generated/numpy.distutils.core.Extension.html
 
 _helloworld_mod = Extension(
     name                   = '_helloworld',

--- a/ISPy/examples/hello_f90/__init__.py
+++ b/ISPy/examples/hello_f90/__init__.py
@@ -8,6 +8,9 @@ This python module is an example from the ISPy python library. It
 illustrates how to wrap Fortran 90 code with F2py.
 """
 
-from _helloworld import *
+try:
+    from _helloworld import *
+except:
+    raise ImportError("Could not load the `{0}' extension, check that it was properly compiled (or reinstall with the `--with-extensions' parameter)".format(__name__))
 
 hello = helloworld.hello

--- a/ISPy/examples/vacuumtoair/__extensions__.ispy
+++ b/ISPy/examples/vacuumtoair/__extensions__.ispy
@@ -1,11 +1,12 @@
 #!/bin/env python
 # -*- coding:utf-8 -*-
 
-from distutils.core import Extension
+from numpy.distutils.core import Extension
 import numpy
 
 # Documentation:
 # https://docs.python.org/3/distutils/apiref.html#distutils.core.Extension
+# https://numpy.org/doc/stable/reference/generated/numpy.distutils.core.Extension.html
 
 _vacuumtoair_mod = Extension(
     '_vacuumtoair',
@@ -22,8 +23,6 @@ _vacuumtoair_mod = Extension(
     export_symbols       = [], # symbols to be exported from a shared extension
     depends              = [], # files that the extension depends on
     language             = '', # 'c', 'c++' or 'objc', normally auto-detected
-    optional             = False
-    # Optional extensions allow the build to continue even when they fail
     )
 
 ext_modules = [_vacuumtoair_mod]

--- a/ISPy/examples/vacuumtoair/__init__.py
+++ b/ISPy/examples/vacuumtoair/__init__.py
@@ -10,4 +10,7 @@ extracted from the rh radiative transfer code and adapted to be
 self-contained.
 """
 
-from _vacuumtoair import *
+try:
+    from _vacuumtoair import *
+except:
+    raise ImportError("Could not load the `{0}' extension, check that it was properly compiled (or reinstall with the `--with-extensions' parameter)".format(__name__))

--- a/setup.py
+++ b/setup.py
@@ -19,15 +19,14 @@ from bin.version import *
 dir_setup = os.path.dirname(os.path.realpath(__file__))
 dir_work  = os.getcwd()
 
-def generate_cython():
+def generate_cython(stop_at_error=False):
     cwd = os.path.abspath(os.path.dirname(__file__))
     print("Cythonizing sources")
     ret = {}
     for d in generate_module_list(os.getcwd()):
         p = subprocess.call([sys.executable, os.path.join(cwd, 'bin', 'cythonize.py'), os.path.join(*'{0}'.format(d).split('.'))], cwd=cwd)
-        # Don't stop on fail
-        # if p != 0:
-        #     raise RuntimeError("Running cythonize failed!")
+        if p != 0 and stop_at_error:
+            raise RuntimeError("Running cythonize failed!")
         ret[d] = p
     return ret
 
@@ -88,7 +87,7 @@ def setup_package():
     if not "--nocython" in sys.argv:
         if "--cythonize" in sys.argv or subprocess.call(['git', 'rev-parse']) is 0 and len(sys.argv) > 1:
             if not "clean" in sys.argv:
-                cython_ret = generate_cython()
+                cython_ret = generate_cython("--cythonize" in sys.argv)
         if "--cythonize" in sys.argv:
             sys.argv.remove("--cythonize")
     else:

--- a/setup.py
+++ b/setup.py
@@ -82,23 +82,33 @@ def setup_package():
     # Rewrite the version file everytime
     write_version_py()
 
+    build_ext = False
     cython_success = True
     cython_ret = {}
     if not "--nocython" in sys.argv:
-        if "--cythonize" in sys.argv or subprocess.call(['git', 'rev-parse']) is 0 and len(sys.argv) > 1:
+        if "--cythonize" in sys.argv or subprocess.call(['git', 'rev-parse']) is 0 and ("--with-extensions" in sys.argv or "build_ext" in sys.argv):
             if not "clean" in sys.argv:
                 cython_ret = generate_cython("--cythonize" in sys.argv)
         if "--cythonize" in sys.argv:
             sys.argv.remove("--cythonize")
     else:
             sys.argv.remove("--nocython")
+    if "--with-extensions" in sys.argv:
+        build_ext = True
+        sys.argv.remove("--with-extensions")
+    if "build_ext" in sys.argv:
+        build_ext = True
 
     with open(str(Path(__file__).parent.joinpath("README.md")), "r") as fh:
         long_description = fh.read()
 
     # Find and prepare extension modules
     ext_modules  = []
-    for m in generate_module_list(os.getcwd(), with_ext=True):
+    if build_ext:
+        mlist = generate_module_list(os.getcwd(), with_ext=True)
+    else:
+        mlist = []
+    for m in mlist:
         # Ignore modules that were not properly cythonized
         if m in cython_ret:
             if cython_ret[m] != 0:


### PR DESCRIPTION
The example extensions now import the _Extension_ class from `numpy.distutils.core` instead of importing it from `distutils.core`; this fixed the compilation with recent versions of NumPy.

In addition, the compilation of extensions is changed in the following way:

- If the `build_ext` command is not invoked explicitly, the extensions are no more built (and cython is not called), unless explicitly requested with the `--with-extensions` flag; if and only if the extensions are to be compiled, the following points further apply:

- If `--cythonize` is not provided to `setup.py`, but we're in a GIT repository, cython is still invoked (no change of behaviour yet), but cython errors are ignored, the respective modules will not be compiled, and a warning is issued at the very end
- If `--cythonize` is provided, errors from cython will **not** be ignored, and the execution will be aborted (it helps for diagnostics during extensions development)
- If `setup.py` is invoked from the directory on which resides an extension, only that extension will be cythonized and compiled (the purpose is to speed up compilation tests during extensions development)