### PR TITLE
[FIX] Updates version number to be valid with PEP440

### DIFF
--- a/bin/generate_module_list.py
+++ b/bin/generate_module_list.py
@@ -61,7 +61,7 @@ def generate_module_list(wdir, with_cython=False, with_ext=False):
         for y in glob(str(Path(__file__).parents[1].absolute().joinpath(x))):
             ok_cython = True
             ok_ext = True
-            if len(glob(join(dirname(y),'*.pyx'))) is 0:
+            if len(glob(join(dirname(y),'*.pyx'))) == 0:
                 ok_cython = not with_cython
             if not isfile(join(dirname(y),'__extensions__.ispy')):
                 ok_ext = not with_ext

--- a/bin/version.py
+++ b/bin/version.py
@@ -21,7 +21,7 @@ def _minimal_ext_cmd(cmd):
     return out
 
 # Return the git revision as a string
-def git_version():
+def git_version(): # This function is not valid under PEP440
 
     try:
         out = _minimal_ext_cmd(['git', 'rev-parse', 'HEAD'])
@@ -50,7 +50,10 @@ def git_version():
 
     return GIT_REVISION, GIT_VERSION_TAG
 
-def get_version_info():
+
+
+
+def get_version_info(): # This function is not valid under PEP440
     # Adding the git rev number needs to be done inside write_version_py(),
     # otherwise the import of ISPy.version messes up the build under Python 3.
     ISRELEASED = False
@@ -79,6 +82,9 @@ def get_version_info():
 
     return VERSION, GIT_REVISION, ISRELEASED
 
+
+
+# This function is not valid under PEP440
 def write_version_py(filename=str(Path(__file__).parents[1].joinpath('ISPy','version.py'))):
     cnt = """
 # THIS FILE IS GENERATED FROM ISPY SETUP.PY
@@ -100,3 +106,27 @@ release = %(isrelease)s
                        'isrelease': str(ISRELEASED)})
     finally:
         a.close()
+
+
+
+
+
+# Adding an alternative way compatible with PEP440:
+def get_pep440version_info():
+    # This version of the function uses the format {tag_name}.dev{num_commits}+{commit_hash} to
+    # indicate that the version number is a development version, with {tag_name} indicating the
+    # name of the latest tag, {num_commits} representing the number of commits since the tag, and
+    # {commit_hash} representing the abbreviated commit hash.
+    git_describe_output = subprocess.check_output(['git', 'describe', '--tags']).decode('utf-8').strip()
+    
+    # Split the output string
+    parts = git_describe_output.split('-')
+    if len(parts) == 1:
+        # No additional commits since the last tag, so this is a release version
+        return parts[0]
+    else:
+        # There are additional commits since the last tag, creating a development version
+        tag_name, num_commits, commit_hash = parts
+        commit_hash = commit_hash[1:]  # Remove the 'g' prefix from the commit hash
+        return f"{tag_name}.dev{num_commits}+{commit_hash}"
+    

--- a/bin/version.py
+++ b/bin/version.py
@@ -54,7 +54,7 @@ def get_version_info():
     # Adding the git rev number needs to be done inside write_version_py(),
     # otherwise the import of ISPy.version messes up the build under Python 3.
     ISRELEASED = False
-    if subprocess.call(['git', 'rev-parse']) is 0:
+    if subprocess.call(['git', 'rev-parse']) == 0:
         GIT_REVISION, VERSION = git_version()
         if VERSION is None:
             VERSION = 'dev-' + GIT_REVISION[:7]

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ def setup_package():
     cython_success = True
     cython_ret = {}
     if not "--nocython" in sys.argv:
-        if "--cythonize" in sys.argv or subprocess.call(['git', 'rev-parse']) is 0 and ("--with-extensions" in sys.argv or "build_ext" in sys.argv):
+        if "--cythonize" in sys.argv or subprocess.call(['git', 'rev-parse']) == 0 and ("--with-extensions" in sys.argv or "build_ext" in sys.argv):
             if not "clean" in sys.argv:
                 cython_ret = generate_cython("--cythonize" in sys.argv)
         if "--cythonize" in sys.argv:
@@ -139,7 +139,8 @@ def setup_package():
 
     setup(
         name                          = "ISPy",
-        version                       = get_version_info()[0],
+        # version                       = get_version_info()[0],
+        version                       = '0.2.0',
         author                        = "ISP-SST",
         author_email                  = "hillberg@astro.su.se",
         description                   = "Commonly used tools at the ISP",

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ class clean(Command):
 
 def setup_package():
     # Rewrite the version file everytime
-    write_version_py()
+    # write_version_py()
 
     build_ext = False
     cython_success = True
@@ -139,8 +139,7 @@ def setup_package():
 
     setup(
         name                          = "ISPy",
-        # version                       = get_version_info()[0],
-        version                       = '0.2.0',
+        version                       = get_pep440version_info(),
         author                        = "ISP-SST",
         author_email                  = "hillberg@astro.su.se",
         description                   = "Commonly used tools at the ISP",


### PR DESCRIPTION
In bin/version.py there is a new function generate_pep440_version(): https://github.com/ISP-SST/ISPy/blob/master/bin/version.py#L115  uses the format {tag_name}.dev{num_commits}+{commit_hash} to indicate that the version number is a development version, with {tag_name} indicating the name of the latest tag, {num_commits} representing the number of commits since the tag, and {commit_hash} representing the abbreviated commit hash. This format is fully compatible with PEP440.